### PR TITLE
Remove alt text fields from GroupImage interface

### DIFF
--- a/src/components/GroupPricing.tsx
+++ b/src/components/GroupPricing.tsx
@@ -14,7 +14,6 @@ export const GroupPricing = () => {
   const carouselImages = adminImages.map((image) => ({
     id: image.id,
     src: image.image,
-    alt: image.alt,
     caption: image.caption,
   }));
 
@@ -161,7 +160,7 @@ export const GroupPricing = () => {
                   >
                     <img
                       src={image.src}
-                      alt={image.alt}
+                      alt=""
                       className="w-full h-full object-cover"
                       style={{ backgroundColor: "#f29200" }}
                     />

--- a/src/components/GroupPricing.tsx
+++ b/src/components/GroupPricing.tsx
@@ -10,12 +10,14 @@ export const GroupPricing = () => {
   const [dragDistance, setDragDistance] = useState(0);
   const { groupImages: adminImages } = useGroupImages();
 
-  // Mostrar todas las imágenes del carrusel
-  const carouselImages = adminImages.map((image) => ({
-    id: image.id,
-    src: image.image,
-    caption: image.caption,
-  }));
+  // Mostrar solo las imágenes activas del carrusel
+  const carouselImages = adminImages
+    .filter((image) => image.active)
+    .map((image) => ({
+      id: image.id,
+      src: image.image,
+      caption: image.caption,
+    }));
 
   useEffect(() => {
     if (carouselImages.length === 0) return;

--- a/src/components/HeroCarousel.tsx
+++ b/src/components/HeroCarousel.tsx
@@ -16,8 +16,8 @@ export const HeroCarousel = () => {
   const carouselRef = useRef<HTMLDivElement>(null);
   const { slides: allSlides } = useHeroSlides();
 
-  // Mostrar todos los slides del carrusel
-  const slides = allSlides;
+  // Mostrar solo los slides activos del carrusel
+  const slides = allSlides.filter((slide) => slide.active);
 
   /**
    * Efecto para cambio automático de slides cada 5 segundos

--- a/src/components/MapSection.tsx
+++ b/src/components/MapSection.tsx
@@ -70,15 +70,14 @@ export const MapSection = () => {
           {/* Botón para ver mapa en grande */}
           <div className="text-center">
             <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
-              <DialogTrigger asChild>
-                <Button
-                  size="lg"
-                  className="bg-park-blue hover:bg-park-blue/90 text-white px-8 py-3 text-lg font-semibold rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg"
-                >
-                  <Expand className="mr-2 h-5 w-5" />
-                  Ver mapa en grande
-                </Button>
-              </DialogTrigger>
+              <Button
+                size="lg"
+                className="bg-park-blue hover:bg-park-blue/90 text-white px-8 py-3 text-lg font-semibold rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg"
+                onClick={() => setIsModalOpen(true)}
+              >
+                <Expand className="mr-2 h-5 w-5" />
+                Ver mapa en grande
+              </Button>
 
               {/* Modal con mapa ampliado */}
               <DialogContent className="max-w-[95vw] max-h-[95vh] p-0 overflow-hidden">

--- a/src/components/MapSection.tsx
+++ b/src/components/MapSection.tsx
@@ -55,7 +55,7 @@ export const MapSection = () => {
             />
 
             {/* Overlay con información */}
-            <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent">
+            <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent pointer-events-none">
               <div className="absolute bottom-4 left-4 right-4 text-white">
                 <h3 className="text-xl font-semibold mb-2">
                   Recorrido Sugerido

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -22,15 +22,17 @@ interface PriceOption {
 export const PricingSection = () => {
   const { priceOptions: adminPriceOptions } = usePriceOptions();
 
-  // Mostrar todas las opciones de precio y mapear al formato correcto
-  const priceOptions: PriceOption[] = adminPriceOptions.map((option) => ({
-    id: option.id,
-    price: option.price,
-    category: option.category,
-    ageRange: option.ageRange,
-    description: option.description,
-    popular: option.category === "Niños", // Mantener lógica de popular para niños
-  }));
+  // Mostrar solo las opciones de precio activas y mapear al formato correcto
+  const priceOptions: PriceOption[] = adminPriceOptions
+    .filter((option) => option.active)
+    .map((option) => ({
+      id: option.id,
+      price: option.price,
+      category: option.category,
+      ageRange: option.ageRange,
+      description: option.description,
+      popular: option.category === "Niños", // Mantener lógica de popular para niños
+    }));
 
   /**
    * Formatea el precio para mostrar

--- a/src/components/WondersSection.tsx
+++ b/src/components/WondersSection.tsx
@@ -30,8 +30,8 @@ export const WondersSection = () => {
   const [hasMoved, setHasMoved] = useState(false);
   const { wonders: allWonders } = useWonders();
 
-  // Mostrar todas las maravillas
-  const wonders: Wonder[] = allWonders;
+  // Mostrar solo las maravillas activas
+  const wonders: Wonder[] = allWonders.filter((wonder) => wonder.active);
 
   /**
    * Inicia el proceso de arrastre del carrusel

--- a/src/components/WondersSection.tsx
+++ b/src/components/WondersSection.tsx
@@ -274,13 +274,6 @@ export const WondersSection = () => {
             <ChevronRight className="h-4 w-4" />
           </Button>
         </div>
-
-        {/* Indicador de deslizamiento */}
-        <div className="text-center mt-8">
-          <p className="text-sm text-gray-500">
-            Desliza horizontalmente para ver más maravillas
-          </p>
-        </div>
       </div>
     </section>
   );

--- a/src/components/ZooSection.tsx
+++ b/src/components/ZooSection.tsx
@@ -19,8 +19,8 @@ export const ZooSection = () => {
   );
   const { animals: adminAnimals } = useAnimals();
 
-  // Mostrar todos los animales
-  const allAnimals: Animal[] = adminAnimals;
+  // Mostrar solo los animales activos
+  const allAnimals: Animal[] = adminAnimals.filter((animal) => animal.active);
 
   // Responsive animals per page: 6 on desktop, 3 on mobile/tablet
   const getAnimalsPerPage = () => {

--- a/src/components/admin/sections/GroupsAdmin.tsx
+++ b/src/components/admin/sections/GroupsAdmin.tsx
@@ -302,7 +302,6 @@ export const GroupsAdmin = () => {
               <Button
                 variant="outline"
                 onClick={() => {
-                  resetForm();
                   setEditingImage(null);
                 }}
               >

--- a/src/components/admin/sections/GroupsAdmin.tsx
+++ b/src/components/admin/sections/GroupsAdmin.tsx
@@ -24,7 +24,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Plus, Edit, Trash2, EyeOff, Eye, Upload, Users } from "lucide-react";
+import { Plus, Edit, Trash2, Upload, Users } from "lucide-react";
 import type { GroupImage } from "@/lib/adminStorage";
 
 export const GroupsAdmin = () => {
@@ -79,13 +79,6 @@ export const GroupsAdmin = () => {
 
   const handleDelete = (id: number) => {
     remove(id);
-  };
-
-  const handleToggleActive = (id: number) => {
-    const image = groupImages.find((img) => img.id === id);
-    if (image) {
-      update(id, { active: !image.active });
-    }
   };
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -193,7 +186,7 @@ export const GroupsAdmin = () => {
         {groupImages.map((image) => (
           <div
             key={image.id}
-            className={`bg-white rounded-lg shadow-lg overflow-hidden ${!image.active ? "opacity-50" : ""}`}
+            className="bg-white rounded-lg shadow-lg overflow-hidden"
           >
             <img
               src={image.image}
@@ -238,17 +231,6 @@ export const GroupsAdmin = () => {
                     </AlertDialogFooter>
                   </AlertDialogContent>
                 </AlertDialog>
-                <button
-                  onClick={() => handleToggleActive(image.id)}
-                  className={`flex-1 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1 ${image.active ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600"}`}
-                >
-                  {image.active ? (
-                    <EyeOff className="w-4 h-4" />
-                  ) : (
-                    <Eye className="w-4 h-4" />
-                  )}
-                  <span>{image.active ? "Ocultar" : "Mostrar"}</span>
-                </button>
               </div>
             </div>
           </div>

--- a/src/components/admin/sections/GroupsAdmin.tsx
+++ b/src/components/admin/sections/GroupsAdmin.tsx
@@ -126,10 +126,10 @@ export const GroupsAdmin = () => {
                       accept="image/*"
                       onChange={handleImageUpload}
                       className="hidden"
-                      id="image-upload-add"
+                      id="groups-image-upload-add"
                     />
                     <label
-                      htmlFor="image-upload-add"
+                      htmlFor="groups-image-upload-add"
                       className="cursor-pointer"
                     >
                       <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
@@ -268,9 +268,12 @@ export const GroupsAdmin = () => {
                     accept="image/*"
                     onChange={handleImageUpload}
                     className="hidden"
-                    id="image-upload-edit"
+                    id="groups-image-upload-edit"
                   />
-                  <label htmlFor="image-upload-edit" className="cursor-pointer">
+                  <label
+                    htmlFor="groups-image-upload-edit"
+                    className="cursor-pointer"
+                  >
                     <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
                     <p className="text-sm text-gray-600">
                       Haz clic para cambiar la imagen

--- a/src/components/admin/sections/GroupsAdmin.tsx
+++ b/src/components/admin/sections/GroupsAdmin.tsx
@@ -246,7 +246,12 @@ export const GroupsAdmin = () => {
       {/* Modal de edición */}
       <Dialog
         open={!!editingImage}
-        onOpenChange={(open) => !open && setEditingImage(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditingImage(null);
+            resetForm();
+          }
+        }}
       >
         <DialogContent className="max-w-2xl">
           <DialogHeader>

--- a/src/components/admin/sections/GroupsAdmin.tsx
+++ b/src/components/admin/sections/GroupsAdmin.tsx
@@ -24,7 +24,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Plus, Edit, Trash2, EyeOff, Upload, Users } from "lucide-react";
+import { Plus, Edit, Trash2, EyeOff, Eye, Upload, Users } from "lucide-react";
 import type { GroupImage } from "@/lib/adminStorage";
 
 export const GroupsAdmin = () => {
@@ -79,6 +79,13 @@ export const GroupsAdmin = () => {
 
   const handleDelete = (id: number) => {
     remove(id);
+  };
+
+  const handleToggleActive = (id: number) => {
+    const image = groupImages.find((img) => img.id === id);
+    if (image) {
+      update(id, { active: !image.active });
+    }
   };
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -182,77 +189,77 @@ export const GroupsAdmin = () => {
       </div>
 
       {/* Lista de imágenes */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <Users className="w-5 h-5 text-blue-600" />
-            <span>Lista de Imágenes del Carrusel Pequeño</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {groupImages.map((image) => (
-              <div
-                key={image.id}
-                className="flex items-center space-x-4 p-4 border rounded-lg bg-white border-gray-200"
-              >
-                <img
-                  src={image.image}
-                  alt=""
-                  className="w-16 h-16 object-cover rounded"
-                />
-                <div className="flex-1">
-                  <h4 className="font-medium text-gray-900">{image.caption}</h4>
-                </div>
-                <div className="flex space-x-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => handleEdit(image)}
-                  >
-                    <Edit className="w-4 h-4" />
-                    Editar
-                  </Button>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {groupImages.map((image) => (
+          <div
+            key={image.id}
+            className={`bg-white rounded-lg shadow-lg overflow-hidden ${!image.active ? "opacity-50" : ""}`}
+          >
+            <img
+              src={image.image}
+              alt=""
+              className="w-full h-48 object-cover"
+            />
+            <div className="p-4">
+              <h3 className="font-bold text-park-blue mb-4">{image.caption}</h3>
 
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button size="sm" variant="destructive">
-                        <Trash2 className="w-4 h-4" />
+              {/* Botones de acción */}
+              <div className="flex space-x-2">
+                <button
+                  onClick={() => handleEdit(image)}
+                  className="flex-1 bg-blue-500 hover:bg-blue-600 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1"
+                >
+                  <Edit className="w-4 h-4" />
+                  <span>Editar</span>
+                </button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <button className="flex-1 bg-red-500 hover:bg-red-600 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1">
+                      <Trash2 className="w-4 h-4" />
+                      <span>Eliminar</span>
+                    </button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>¿Eliminar imagen?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Esta acción no se puede deshacer. La imagen se eliminará
+                        permanentemente.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => handleDelete(image.id)}
+                        className="bg-red-600 hover:bg-red-700"
+                      >
                         Eliminar
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>¿Eliminar imagen?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Esta acción no se puede deshacer. La imagen se
-                          eliminará permanentemente.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={() => handleDelete(image.id)}
-                          className="bg-red-600 hover:bg-red-700"
-                        >
-                          Eliminar
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                </div>
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+                <button
+                  onClick={() => handleToggleActive(image.id)}
+                  className={`flex-1 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1 ${image.active ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600"}`}
+                >
+                  {image.active ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                  <span>{image.active ? "Ocultar" : "Mostrar"}</span>
+                </button>
               </div>
-            ))}
-
-            {groupImages.length === 0 && (
-              <div className="text-center py-8 text-gray-500">
-                No hay imágenes. Haz clic en "Agregar" para añadir la primera
-                imagen.
-              </div>
-            )}
+            </div>
           </div>
-        </CardContent>
-      </Card>
+        ))}
+      </div>
+
+      {groupImages.length === 0 && (
+        <div className="text-center py-8 text-gray-500">
+          No hay imágenes. Haz clic en "Agregar" para añadir la primera imagen.
+        </div>
+      )}
 
       {/* Modal de edición */}
       <Dialog

--- a/src/components/admin/sections/GroupsAdmin.tsx
+++ b/src/components/admin/sections/GroupsAdmin.tsx
@@ -33,24 +33,21 @@ export const GroupsAdmin = () => {
   const [editingImage, setEditingImage] = useState<GroupImage | null>(null);
   const [formData, setFormData] = useState({
     image: "",
-    alt: "",
     caption: "",
   });
 
   const resetForm = () => {
     setFormData({
       image: "",
-      alt: "",
       caption: "",
     });
   };
 
   const handleAdd = () => {
-    if (!formData.image || !formData.alt || !formData.caption) return;
+    if (!formData.image || !formData.caption) return;
 
     add({
       image: formData.image,
-      alt: formData.alt,
       caption: formData.caption,
       active: true,
     });
@@ -63,18 +60,15 @@ export const GroupsAdmin = () => {
     setEditingImage(image);
     setFormData({
       image: image.image,
-      alt: image.alt,
       caption: image.caption,
     });
   };
 
   const handleUpdate = () => {
-    if (!editingImage || !formData.image || !formData.alt || !formData.caption)
-      return;
+    if (!editingImage || !formData.image || !formData.caption) return;
 
     update(editingImage.id, {
       image: formData.image,
-      alt: formData.alt,
       caption: formData.caption,
       active: editingImage.active,
     });
@@ -147,19 +141,6 @@ export const GroupsAdmin = () => {
                 </div>
               </div>
 
-              {/* Campo Alt */}
-              <div className="space-y-2">
-                <Label htmlFor="alt-add">Texto alternativo</Label>
-                <Input
-                  id="alt-add"
-                  value={formData.alt}
-                  onChange={(e) =>
-                    setFormData((prev) => ({ ...prev, alt: e.target.value }))
-                  }
-                  placeholder="Descripción de la imagen para accesibilidad"
-                />
-              </div>
-
               {/* Campo Caption */}
               <div className="space-y-2">
                 <Label htmlFor="caption-add">Texto de la imagen</Label>
@@ -189,9 +170,7 @@ export const GroupsAdmin = () => {
                 </Button>
                 <Button
                   onClick={handleAdd}
-                  disabled={
-                    !formData.image || !formData.alt || !formData.caption
-                  }
+                  disabled={!formData.image || !formData.caption}
                   className="bg-blue-600 hover:bg-blue-700"
                 >
                   Agregar
@@ -219,12 +198,11 @@ export const GroupsAdmin = () => {
               >
                 <img
                   src={image.image}
-                  alt={image.alt}
+                  alt=""
                   className="w-16 h-16 object-cover rounded"
                 />
                 <div className="flex-1">
-                  <h4 className="font-medium text-gray-900">{image.alt}</h4>
-                  <p className="text-sm text-gray-600">{image.caption}</p>
+                  <h4 className="font-medium text-gray-900">{image.caption}</h4>
                 </div>
                 <div className="flex space-x-2">
                   <Button
@@ -317,19 +295,6 @@ export const GroupsAdmin = () => {
               </div>
             </div>
 
-            {/* Campo Alt */}
-            <div className="space-y-2">
-              <Label htmlFor="alt-edit">Texto alternativo</Label>
-              <Input
-                id="alt-edit"
-                value={formData.alt}
-                onChange={(e) =>
-                  setFormData((prev) => ({ ...prev, alt: e.target.value }))
-                }
-                placeholder="Descripción de la imagen para accesibilidad"
-              />
-            </div>
-
             {/* Campo Caption */}
             <div className="space-y-2">
               <Label htmlFor="caption-edit">Texto de la imagen</Label>
@@ -356,7 +321,7 @@ export const GroupsAdmin = () => {
               </Button>
               <Button
                 onClick={handleUpdate}
-                disabled={!formData.image || !formData.alt || !formData.caption}
+                disabled={!formData.image || !formData.caption}
                 className="bg-blue-600 hover:bg-blue-700"
               >
                 Actualizar

--- a/src/components/admin/sections/HeroCarouselAdmin.tsx
+++ b/src/components/admin/sections/HeroCarouselAdmin.tsx
@@ -378,7 +378,6 @@ export const HeroCarouselAdmin = () => {
               <Button
                 variant="outline"
                 onClick={() => {
-                  resetForm();
                   setEditingSlide(null);
                 }}
               >

--- a/src/components/admin/sections/HeroCarouselAdmin.tsx
+++ b/src/components/admin/sections/HeroCarouselAdmin.tsx
@@ -24,7 +24,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Plus, Edit, Trash2, EyeOff, Upload, Camera } from "lucide-react";
+import { Plus, Edit, Trash2, EyeOff, Eye, Upload, Camera } from "lucide-react";
 import type { HeroSlide } from "@/lib/adminStorage";
 
 export const HeroCarouselAdmin = () => {
@@ -79,6 +79,13 @@ export const HeroCarouselAdmin = () => {
 
   const handleDelete = (id: number) => {
     remove(id);
+  };
+
+  const handleToggleActive = (id: number) => {
+    const slide = slides.find((s) => s.id === id);
+    if (slide) {
+      update(id, { active: !slide.active });
+    }
   };
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -222,82 +229,83 @@ export const HeroCarouselAdmin = () => {
         </Dialog>
       </div>
 
-      {/* Lista de imágenes */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <Camera className="w-5 h-5 text-blue-600" />
-            <span>Lista de Imágenes del Carrusel</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {slides.map((slide) => (
-              <div
-                key={slide.id}
-                className="flex items-center space-x-4 p-4 border rounded-lg bg-white border-gray-200"
-              >
-                <img
-                  src={slide.image}
-                  alt={slide.title}
-                  className="w-16 h-16 object-cover rounded"
-                />
-                <div className="flex-1">
-                  <h4 className="font-medium text-gray-900">{slide.title}</h4>
-                  <p className="text-sm text-gray-600">{slide.subtitle}</p>
-                  <p className="text-xs text-gray-500 mt-1 line-clamp-2">
-                    {slide.description}
-                  </p>
-                </div>
-                <div className="flex space-x-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => handleEdit(slide)}
-                  >
-                    <Edit className="w-4 h-4" />
-                    Editar
-                  </Button>
+      {/* Lista de slides */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {slides.map((slide) => (
+          <div
+            key={slide.id}
+            className={`bg-white rounded-lg shadow-lg overflow-hidden ${!slide.active ? "opacity-50" : ""}`}
+          >
+            <img
+              src={slide.image}
+              alt={slide.title}
+              className="w-full h-48 object-cover"
+            />
+            <div className="p-4">
+              <p className="text-sm text-park-orange mb-2">{slide.subtitle}</p>
+              <h3 className="font-bold text-park-blue mb-2">{slide.title}</h3>
+              <p className="text-sm text-gray-600 mb-4 line-clamp-2">
+                {slide.description}
+              </p>
 
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button size="sm" variant="destructive">
-                        <Trash2 className="w-4 h-4" />
+              {/* Botones de acción */}
+              <div className="flex space-x-2">
+                <button
+                  onClick={() => handleEdit(slide)}
+                  className="flex-1 bg-blue-500 hover:bg-blue-600 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1"
+                >
+                  <Edit className="w-4 h-4" />
+                  <span>Editar</span>
+                </button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <button className="flex-1 bg-red-500 hover:bg-red-600 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1">
+                      <Trash2 className="w-4 h-4" />
+                      <span>Eliminar</span>
+                    </button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>¿Eliminar imagen?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Esta acción no se puede deshacer. La imagen se eliminará
+                        permanentemente.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => handleDelete(slide.id)}
+                        className="bg-red-600 hover:bg-red-700"
+                      >
                         Eliminar
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>¿Eliminar imagen?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Esta acción no se puede deshacer. La imagen se
-                          eliminará permanentemente.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={() => handleDelete(slide.id)}
-                          className="bg-red-600 hover:bg-red-700"
-                        >
-                          Eliminar
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                </div>
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+                <button
+                  onClick={() => handleToggleActive(slide.id)}
+                  className={`flex-1 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1 ${slide.active ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600"}`}
+                >
+                  {slide.active ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                  <span>{slide.active ? "Ocultar" : "Mostrar"}</span>
+                </button>
               </div>
-            ))}
-
-            {slides.length === 0 && (
-              <div className="text-center py-8 text-gray-500">
-                No hay imágenes en el carrusel. Haz clic en "Agregar" para
-                añadir la primera imagen.
-              </div>
-            )}
+            </div>
           </div>
-        </CardContent>
-      </Card>
+        ))}
+      </div>
+
+      {slides.length === 0 && (
+        <div className="text-center py-8 text-gray-500">
+          No hay imágenes en el carrusel. Haz clic en "Agregar" para añadir la
+          primera imagen.
+        </div>
+      )}
 
       {/* Modal de edición */}
       <Dialog

--- a/src/components/admin/sections/HeroCarouselAdmin.tsx
+++ b/src/components/admin/sections/HeroCarouselAdmin.tsx
@@ -24,7 +24,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Plus, Edit, Trash2, EyeOff, Eye, Upload, Camera } from "lucide-react";
+import { Plus, Edit, Trash2, Upload, Camera } from "lucide-react";
 import type { HeroSlide } from "@/lib/adminStorage";
 
 export const HeroCarouselAdmin = () => {
@@ -79,13 +79,6 @@ export const HeroCarouselAdmin = () => {
 
   const handleDelete = (id: number) => {
     remove(id);
-  };
-
-  const handleToggleActive = (id: number) => {
-    const slide = slides.find((s) => s.id === id);
-    if (slide) {
-      update(id, { active: !slide.active });
-    }
   };
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -234,7 +227,7 @@ export const HeroCarouselAdmin = () => {
         {slides.map((slide) => (
           <div
             key={slide.id}
-            className={`bg-white rounded-lg shadow-lg overflow-hidden ${!slide.active ? "opacity-50" : ""}`}
+            className="bg-white rounded-lg shadow-lg overflow-hidden"
           >
             <img
               src={slide.image}
@@ -283,17 +276,6 @@ export const HeroCarouselAdmin = () => {
                     </AlertDialogFooter>
                   </AlertDialogContent>
                 </AlertDialog>
-                <button
-                  onClick={() => handleToggleActive(slide.id)}
-                  className={`flex-1 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1 ${slide.active ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600"}`}
-                >
-                  {slide.active ? (
-                    <EyeOff className="w-4 h-4" />
-                  ) : (
-                    <Eye className="w-4 h-4" />
-                  )}
-                  <span>{slide.active ? "Ocultar" : "Mostrar"}</span>
-                </button>
               </div>
             </div>
           </div>

--- a/src/components/admin/sections/HeroCarouselAdmin.tsx
+++ b/src/components/admin/sections/HeroCarouselAdmin.tsx
@@ -292,7 +292,12 @@ export const HeroCarouselAdmin = () => {
       {/* Modal de edición */}
       <Dialog
         open={!!editingSlide}
-        onOpenChange={(open) => !open && setEditingSlide(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditingSlide(null);
+            resetForm();
+          }
+        }}
       >
         <DialogContent className="max-w-2xl">
           <DialogHeader>

--- a/src/components/admin/sections/HeroCarouselAdmin.tsx
+++ b/src/components/admin/sections/HeroCarouselAdmin.tsx
@@ -128,10 +128,10 @@ export const HeroCarouselAdmin = () => {
                       accept="image/*"
                       onChange={handleImageUpload}
                       className="hidden"
-                      id="image-upload-add"
+                      id="hero-image-upload-add"
                     />
                     <label
-                      htmlFor="image-upload-add"
+                      htmlFor="hero-image-upload-add"
                       className="cursor-pointer"
                     >
                       <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
@@ -314,9 +314,12 @@ export const HeroCarouselAdmin = () => {
                     accept="image/*"
                     onChange={handleImageUpload}
                     className="hidden"
-                    id="image-upload-edit"
+                    id="hero-image-upload-edit"
                   />
-                  <label htmlFor="image-upload-edit" className="cursor-pointer">
+                  <label
+                    htmlFor="hero-image-upload-edit"
+                    className="cursor-pointer"
+                  >
                     <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
                     <p className="text-sm text-gray-600">
                       Haz clic para cambiar la imagen

--- a/src/components/admin/sections/MapAdmin.tsx
+++ b/src/components/admin/sections/MapAdmin.tsx
@@ -1,28 +1,14 @@
 import { useState } from "react";
 import { useMapData } from "@/hooks/useAdminData";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
-import { Label } from "@/components/ui/label";
-import { cn } from "@/lib/utils";
-import { Edit, EyeOff, Upload, Map } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Edit, EyeOff, Eye, Upload } from "lucide-react";
 
 export const MapAdmin = () => {
   const { mapData, update, toggleActive } = useMapData();
@@ -31,13 +17,17 @@ export const MapAdmin = () => {
     image: "",
   });
 
-  const handleEdit = () => {
+  const handleImageChange = () => {
     if (mapData) {
       setFormData({
         image: mapData.image,
       });
       setIsEditModalOpen(true);
     }
+  };
+
+  const handleToggleActive = () => {
+    toggleActive();
   };
 
   const handleUpdate = () => {
@@ -66,7 +56,6 @@ export const MapAdmin = () => {
     return (
       <div className="space-y-6">
         <div className="text-center py-12">
-          <Map className="w-12 h-12 text-gray-400 mx-auto mb-4" />
           <h2 className="text-xl font-semibold text-gray-600 mb-2">
             No hay datos del mapa
           </h2>
@@ -88,93 +77,56 @@ export const MapAdmin = () => {
         </p>
       </div>
 
-      {/* Card del mapa */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <Map className="w-5 h-5 text-blue-600" />
-            <span>Imagen del Mapa</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div
-            className={cn(
-              "flex items-center space-x-4 p-4 border rounded-lg",
-              mapData.active
-                ? "bg-white border-gray-200"
-                : "bg-gray-100 border-gray-300",
-            )}
-          >
-            <img
-              src={mapData.image}
-              alt="Mapa del parque"
-              className={cn(
-                "w-24 h-24 object-cover rounded cursor-pointer hover:opacity-80 transition-opacity",
-                !mapData.active && "grayscale",
-              )}
-              onClick={() =>
-                window.open(
-                  `/mapa-grande?img=${encodeURIComponent(mapData.image)}`,
-                  "_blank",
-                )
-              }
-            />
-            <div className="flex-1">
-              <h4 className="font-medium text-gray-900">Mapa del Parque</h4>
-              <p className="text-sm text-gray-600">
-                Imagen principal del mapa del parque zonal
-              </p>
-              <p
-                className={cn(
-                  "text-xs mt-1",
-                  mapData.active ? "text-green-600" : "text-gray-500",
-                )}
-              >
-                Estado: {mapData.active ? "Visible" : "Oculto"}
-              </p>
-            </div>
-            <div className="flex space-x-2">
-              <Button size="sm" variant="outline" onClick={handleEdit}>
-                <Edit className="w-4 h-4" />
-                Editar
-              </Button>
+      {/* Card design */}
+      <div className="max-w-2xl">
+        <div className="bg-white rounded-lg shadow-lg overflow-hidden">
+          <img
+            src={mapData.image || "/placeholder.svg"}
+            alt="Mapa del Parque"
+            className={`w-full h-64 object-cover ${!mapData.active ? "opacity-50" : ""}`}
+            onError={(e) => {
+              e.currentTarget.src = "/placeholder.svg";
+            }}
+          />
+          <div className="p-6">
+            <h3 className="text-lg font-bold text-park-blue mb-4">
+              Mapa Actual del Parque
+            </h3>
+            <p className="text-gray-600 mb-6">
+              Esta es la imagen que se muestra en la sección "Mapa del Parque"
+              de la homepage.
+            </p>
 
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button size="sm" variant="outline">
-                    <EyeOff className="w-4 h-4" />
-                    Desactivar
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      {mapData.active ? "¿Desactivar mapa?" : "¿Activar mapa?"}
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      {mapData.active
-                        ? "La imagen se desactivará y no se mostrará en la sección Mapa del Parque. Se colocará de color gris."
-                        : "La imagen volverá a mostrarse en la sección Mapa del Parque."}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                    <AlertDialogAction onClick={toggleActive}>
-                      Confirmar
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+            <div className="flex space-x-4">
+              <button
+                onClick={handleImageChange}
+                className="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg flex items-center space-x-2 transition-colors"
+              >
+                <Edit className="w-5 h-5" />
+                <span>Cambiar Imagen</span>
+              </button>
+
+              <button
+                onClick={handleToggleActive}
+                className={`font-semibold py-2 px-4 rounded-lg flex items-center space-x-2 transition-colors ${mapData.active ? "bg-gray-500 hover:bg-gray-600 text-white" : "bg-green-500 hover:bg-green-600 text-white"}`}
+              >
+                {mapData.active ? (
+                  <EyeOff className="w-5 h-5" />
+                ) : (
+                  <Eye className="w-5 h-5" />
+                )}
+                <span>{mapData.active ? "Desactivar" : "Activar"}</span>
+              </button>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </div>
 
       {/* Modal de edición */}
       <Dialog open={isEditModalOpen} onOpenChange={setIsEditModalOpen}>
         <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Editar Mapa del Parque</DialogTitle>
+            <DialogTitle>Cambiar Imagen del Mapa</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
             {/* Vista de imagen actual */}

--- a/src/components/admin/sections/MapAdmin.tsx
+++ b/src/components/admin/sections/MapAdmin.tsx
@@ -151,9 +151,12 @@ export const MapAdmin = () => {
                     accept="image/*"
                     onChange={handleImageUpload}
                     className="hidden"
-                    id="image-upload-edit"
+                    id="map-image-upload-edit"
                   />
-                  <label htmlFor="image-upload-edit" className="cursor-pointer">
+                  <label
+                    htmlFor="map-image-upload-edit"
+                    className="cursor-pointer"
+                  >
                     <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
                     <p className="text-sm text-gray-600">
                       Haz clic para seleccionar una nueva imagen del mapa

--- a/src/components/admin/sections/PricingAdmin.tsx
+++ b/src/components/admin/sections/PricingAdmin.tsx
@@ -23,7 +23,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { Plus, Edit, Trash2, EyeOff, Eye, DollarSign } from "lucide-react";
+import { Plus, Edit, Trash2, DollarSign } from "lucide-react";
 import type { PriceOption } from "@/lib/adminStorage";
 
 const colorOptions = [
@@ -98,13 +98,6 @@ export const PricingAdmin = () => {
 
   const handleDelete = (id: number) => {
     remove(id);
-  };
-
-  const handleToggleActive = (id: number) => {
-    const option = priceOptions.find((opt) => opt.id === id);
-    if (option) {
-      update(id, { active: !option.active });
-    }
   };
 
   const formatPrice = (price: number) => {
@@ -247,7 +240,7 @@ export const PricingAdmin = () => {
         {priceOptions.map((option) => (
           <div
             key={option.id}
-            className={`bg-white rounded-lg shadow-lg overflow-hidden ${!option.active ? "opacity-50" : ""}`}
+            className="bg-white rounded-lg shadow-lg overflow-hidden"
           >
             <div className="p-4 text-center">
               <div
@@ -301,17 +294,6 @@ export const PricingAdmin = () => {
                     </AlertDialogFooter>
                   </AlertDialogContent>
                 </AlertDialog>
-                <button
-                  onClick={() => handleToggleActive(option.id)}
-                  className={`flex-1 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1 ${option.active ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600"}`}
-                >
-                  {option.active ? (
-                    <EyeOff className="w-4 h-4" />
-                  ) : (
-                    <Eye className="w-4 h-4" />
-                  )}
-                  <span>{option.active ? "Ocultar" : "Mostrar"}</span>
-                </button>
               </div>
             </div>
           </div>

--- a/src/components/admin/sections/PricingAdmin.tsx
+++ b/src/components/admin/sections/PricingAdmin.tsx
@@ -23,7 +23,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { Plus, Edit, Trash2, EyeOff, DollarSign } from "lucide-react";
+import { Plus, Edit, Trash2, EyeOff, Eye, DollarSign } from "lucide-react";
 import type { PriceOption } from "@/lib/adminStorage";
 
 const colorOptions = [
@@ -98,6 +98,13 @@ export const PricingAdmin = () => {
 
   const handleDelete = (id: number) => {
     remove(id);
+  };
+
+  const handleToggleActive = (id: number) => {
+    const option = priceOptions.find((opt) => opt.id === id);
+    if (option) {
+      update(id, { active: !option.active });
+    }
   };
 
   const formatPrice = (price: number) => {
@@ -236,86 +243,86 @@ export const PricingAdmin = () => {
       </div>
 
       {/* Lista de cards */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <DollarSign className="w-5 h-5 text-blue-600" />
-            <span>Lista de Cards de Precios</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {priceOptions.map((option) => (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {priceOptions.map((option) => (
+          <div
+            key={option.id}
+            className={`bg-white rounded-lg shadow-lg overflow-hidden ${!option.active ? "opacity-50" : ""}`}
+          >
+            <div className="p-4 text-center">
               <div
-                key={option.id}
-                className="flex items-center space-x-4 p-4 border rounded-lg bg-white border-gray-200"
+                className="w-16 h-16 rounded-full flex items-center justify-center text-white font-bold text-sm mx-auto mb-3"
+                style={{ backgroundColor: option.color }}
               >
-                <div
-                  className="w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-sm"
-                  style={{ backgroundColor: option.color }}
+                {formatPrice(option.price)}
+              </div>
+              <h3 className="font-bold text-park-blue mb-2">
+                {option.category}
+              </h3>
+              <p className="text-sm text-gray-600 mb-2">{option.ageRange}</p>
+              {option.description && (
+                <p className="text-xs text-gray-500 mb-4">
+                  {option.description}
+                </p>
+              )}
+
+              {/* Botones de acción */}
+              <div className="flex space-x-2">
+                <button
+                  onClick={() => handleEdit(option)}
+                  className="flex-1 bg-blue-500 hover:bg-blue-600 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1"
                 >
-                  {formatPrice(option.price)}
-                </div>
-                <div className="flex-1">
-                  <h4 className="font-medium text-gray-900">
-                    {option.category}
-                  </h4>
-                  <p className="text-sm text-gray-600">{option.ageRange}</p>
-                  {option.description && (
-                    <p className="text-xs text-gray-500 mt-1">
-                      {option.description}
-                    </p>
-                  )}
-                </div>
-                <div className="flex space-x-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => handleEdit(option)}
-                  >
-                    <Edit className="w-4 h-4" />
-                    Editar
-                  </Button>
-
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button size="sm" variant="destructive">
-                        <Trash2 className="w-4 h-4" />
+                  <Edit className="w-4 h-4" />
+                  <span>Editar</span>
+                </button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <button className="flex-1 bg-red-500 hover:bg-red-600 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1">
+                      <Trash2 className="w-4 h-4" />
+                      <span>Eliminar</span>
+                    </button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>¿Eliminar card?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Esta acción no se puede deshacer. La card se eliminará
+                        permanentemente.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => handleDelete(option.id)}
+                        className="bg-red-600 hover:bg-red-700"
+                      >
                         Eliminar
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>¿Eliminar card?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Esta acción no se puede deshacer. La card se eliminará
-                          permanentemente.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={() => handleDelete(option.id)}
-                          className="bg-red-600 hover:bg-red-700"
-                        >
-                          Eliminar
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                </div>
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+                <button
+                  onClick={() => handleToggleActive(option.id)}
+                  className={`flex-1 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1 ${option.active ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600"}`}
+                >
+                  {option.active ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                  <span>{option.active ? "Ocultar" : "Mostrar"}</span>
+                </button>
               </div>
-            ))}
-
-            {priceOptions.length === 0 && (
-              <div className="text-center py-8 text-gray-500">
-                No hay precios. Haz clic en "Agregar" para añadir el primer
-                precio.
-              </div>
-            )}
+            </div>
           </div>
-        </CardContent>
-      </Card>
+        ))}
+      </div>
+
+      {priceOptions.length === 0 && (
+        <div className="text-center py-8 text-gray-500">
+          No hay precios. Haz clic en "Agregar" para añadir el primer precio.
+        </div>
+      )}
 
       {/* Modal de edición */}
       <Dialog

--- a/src/components/admin/sections/WondersAdmin.tsx
+++ b/src/components/admin/sections/WondersAdmin.tsx
@@ -381,7 +381,6 @@ export const WondersAdmin = () => {
               <Button
                 variant="outline"
                 onClick={() => {
-                  resetForm();
                   setEditingWonder(null);
                 }}
               >

--- a/src/components/admin/sections/WondersAdmin.tsx
+++ b/src/components/admin/sections/WondersAdmin.tsx
@@ -24,7 +24,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Plus, Edit, Trash2, EyeOff, Eye, Upload, Globe } from "lucide-react";
+import { Plus, Edit, Trash2, Upload, Globe } from "lucide-react";
 import type { Wonder } from "@/lib/adminStorage";
 
 export const WondersAdmin = () => {
@@ -87,13 +87,6 @@ export const WondersAdmin = () => {
 
   const handleDelete = (id: number) => {
     remove(id);
-  };
-
-  const handleToggleActive = (id: number) => {
-    const wonder = wonders.find((w) => w.id === id);
-    if (wonder) {
-      update(id, { active: !wonder.active });
-    }
   };
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -234,7 +227,7 @@ export const WondersAdmin = () => {
         {wonders.map((wonder) => (
           <div
             key={wonder.id}
-            className={`bg-white rounded-lg shadow-lg overflow-hidden ${!wonder.active ? "opacity-50" : ""}`}
+            className="bg-white rounded-lg shadow-lg overflow-hidden"
           >
             <img
               src={wonder.image}
@@ -282,17 +275,6 @@ export const WondersAdmin = () => {
                     </AlertDialogFooter>
                   </AlertDialogContent>
                 </AlertDialog>
-                <button
-                  onClick={() => handleToggleActive(wonder.id)}
-                  className={`flex-1 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1 ${wonder.active ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600"}`}
-                >
-                  {wonder.active ? (
-                    <EyeOff className="w-4 h-4" />
-                  ) : (
-                    <Eye className="w-4 h-4" />
-                  )}
-                  <span>{wonder.active ? "Ocultar" : "Mostrar"}</span>
-                </button>
               </div>
             </div>
           </div>

--- a/src/components/admin/sections/WondersAdmin.tsx
+++ b/src/components/admin/sections/WondersAdmin.tsx
@@ -24,7 +24,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Plus, Edit, Trash2, EyeOff, Upload, Globe } from "lucide-react";
+import { Plus, Edit, Trash2, EyeOff, Eye, Upload, Globe } from "lucide-react";
 import type { Wonder } from "@/lib/adminStorage";
 
 export const WondersAdmin = () => {
@@ -87,6 +87,13 @@ export const WondersAdmin = () => {
 
   const handleDelete = (id: number) => {
     remove(id);
+  };
+
+  const handleToggleActive = (id: number) => {
+    const wonder = wonders.find((w) => w.id === id);
+    if (wonder) {
+      update(id, { active: !wonder.active });
+    }
   };
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -223,78 +230,81 @@ export const WondersAdmin = () => {
       </div>
 
       {/* Lista de tarjetas */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <Globe className="w-5 h-5 text-blue-600" />
-            <span>Lista de Tarjetas de Maravillas</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {wonders.map((wonder) => (
-              <div
-                key={wonder.id}
-                className="flex items-center space-x-4 p-4 border rounded-lg bg-white border-gray-200"
-              >
-                <img
-                  src={wonder.image}
-                  alt={wonder.name}
-                  className="w-16 h-16 object-cover rounded"
-                />
-                <div className="flex-1">
-                  <h4 className="font-medium text-gray-900">{wonder.name}</h4>
-                  <p className="text-sm text-gray-600">{wonder.description}</p>
-                </div>
-                <div className="flex space-x-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => handleEdit(wonder)}
-                  >
-                    <Edit className="w-4 h-4" />
-                    Editar
-                  </Button>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {wonders.map((wonder) => (
+          <div
+            key={wonder.id}
+            className={`bg-white rounded-lg shadow-lg overflow-hidden ${!wonder.active ? "opacity-50" : ""}`}
+          >
+            <img
+              src={wonder.image}
+              alt={wonder.name}
+              className="w-full h-48 object-cover"
+            />
+            <div className="p-4">
+              <p className="text-sm text-park-orange mb-2">
+                {wonder.description}
+              </p>
+              <h3 className="font-bold text-park-blue mb-4">{wonder.name}</h3>
 
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button size="sm" variant="destructive">
-                        <Trash2 className="w-4 h-4" />
+              {/* Botones de acción */}
+              <div className="flex space-x-2">
+                <button
+                  onClick={() => handleEdit(wonder)}
+                  className="flex-1 bg-blue-500 hover:bg-blue-600 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1"
+                >
+                  <Edit className="w-4 h-4" />
+                  <span>Editar</span>
+                </button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <button className="flex-1 bg-red-500 hover:bg-red-600 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1">
+                      <Trash2 className="w-4 h-4" />
+                      <span>Eliminar</span>
+                    </button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>¿Eliminar tarjeta?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Esta acción no se puede deshacer. La tarjeta se
+                        eliminará permanentemente.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => handleDelete(wonder.id)}
+                        className="bg-red-600 hover:bg-red-700"
+                      >
                         Eliminar
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>¿Eliminar tarjeta?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Esta acción no se puede deshacer. La tarjeta se
-                          eliminará permanentemente.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={() => handleDelete(wonder.id)}
-                          className="bg-red-600 hover:bg-red-700"
-                        >
-                          Eliminar
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                </div>
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+                <button
+                  onClick={() => handleToggleActive(wonder.id)}
+                  className={`flex-1 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1 ${wonder.active ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600"}`}
+                >
+                  {wonder.active ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                  <span>{wonder.active ? "Ocultar" : "Mostrar"}</span>
+                </button>
               </div>
-            ))}
-
-            {wonders.length === 0 && (
-              <div className="text-center py-8 text-gray-500">
-                No hay maravillas. Haz clic en "Agregar" para añadir la primera
-                maravilla.
-              </div>
-            )}
+            </div>
           </div>
-        </CardContent>
-      </Card>
+        ))}
+      </div>
+
+      {wonders.length === 0 && (
+        <div className="text-center py-8 text-gray-500">
+          No hay maravillas. Haz clic en "Agregar" para añadir la primera
+          maravilla.
+        </div>
+      )}
 
       {/* Modal de edición */}
       <Dialog

--- a/src/components/admin/sections/WondersAdmin.tsx
+++ b/src/components/admin/sections/WondersAdmin.tsx
@@ -291,7 +291,12 @@ export const WondersAdmin = () => {
       {/* Modal de edición */}
       <Dialog
         open={!!editingWonder}
-        onOpenChange={(open) => !open && setEditingWonder(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditingWonder(null);
+            resetForm();
+          }
+        }}
       >
         <DialogContent className="max-w-2xl">
           <DialogHeader>

--- a/src/components/admin/sections/WondersAdmin.tsx
+++ b/src/components/admin/sections/WondersAdmin.tsx
@@ -136,10 +136,10 @@ export const WondersAdmin = () => {
                       accept="image/*"
                       onChange={handleImageUpload}
                       className="hidden"
-                      id="image-upload-add"
+                      id="wonders-image-upload-add"
                     />
                     <label
-                      htmlFor="image-upload-add"
+                      htmlFor="wonders-image-upload-add"
                       className="cursor-pointer"
                     >
                       <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
@@ -313,9 +313,12 @@ export const WondersAdmin = () => {
                     accept="image/*"
                     onChange={handleImageUpload}
                     className="hidden"
-                    id="image-upload-edit"
+                    id="wonders-image-upload-edit"
                   />
-                  <label htmlFor="image-upload-edit" className="cursor-pointer">
+                  <label
+                    htmlFor="wonders-image-upload-edit"
+                    className="cursor-pointer"
+                  >
                     <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
                     <p className="text-sm text-gray-600">
                       Haz clic para cambiar la imagen

--- a/src/components/admin/sections/ZooAdmin.tsx
+++ b/src/components/admin/sections/ZooAdmin.tsx
@@ -407,7 +407,6 @@ export const ZooAdmin = () => {
               <Button
                 variant="outline"
                 onClick={() => {
-                  resetForm();
                   setEditingAnimal(null);
                 }}
               >

--- a/src/components/admin/sections/ZooAdmin.tsx
+++ b/src/components/admin/sections/ZooAdmin.tsx
@@ -147,10 +147,10 @@ export const ZooAdmin = () => {
                       accept="image/*"
                       onChange={handleImageUpload}
                       className="hidden"
-                      id="image-upload-add"
+                      id="zoo-image-upload-add"
                     />
                     <label
-                      htmlFor="image-upload-add"
+                      htmlFor="zoo-image-upload-add"
                       className="cursor-pointer"
                     >
                       <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
@@ -340,9 +340,12 @@ export const ZooAdmin = () => {
                     accept="image/*"
                     onChange={handleImageUpload}
                     className="hidden"
-                    id="image-upload-edit"
+                    id="zoo-image-upload-edit"
                   />
-                  <label htmlFor="image-upload-edit" className="cursor-pointer">
+                  <label
+                    htmlFor="zoo-image-upload-edit"
+                    className="cursor-pointer"
+                  >
                     <Upload className="w-8 h-8 text-gray-400 mx-auto mb-2" />
                     <p className="text-sm text-gray-600">
                       Haz clic para cambiar la imagen

--- a/src/components/admin/sections/ZooAdmin.tsx
+++ b/src/components/admin/sections/ZooAdmin.tsx
@@ -318,7 +318,12 @@ export const ZooAdmin = () => {
       {/* Modal de edición */}
       <Dialog
         open={!!editingAnimal}
-        onOpenChange={(open) => !open && setEditingAnimal(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditingAnimal(null);
+            resetForm();
+          }
+        }}
       >
         <DialogContent className="max-w-2xl">
           <DialogHeader>

--- a/src/components/admin/sections/ZooAdmin.tsx
+++ b/src/components/admin/sections/ZooAdmin.tsx
@@ -24,7 +24,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Plus, Edit, Trash2, EyeOff, Upload, PawPrint } from "lucide-react";
+import {
+  Plus,
+  Edit,
+  Trash2,
+  EyeOff,
+  Eye,
+  Upload,
+  PawPrint,
+} from "lucide-react";
 import type { Animal } from "@/lib/adminStorage";
 
 export const ZooAdmin = () => {
@@ -85,6 +93,13 @@ export const ZooAdmin = () => {
 
   const handleDelete = (id: number) => {
     remove(id);
+  };
+
+  const handleToggleActive = (id: number) => {
+    const animal = animals.find((a) => a.id === id);
+    if (animal) {
+      update(id, { active: !animal.active });
+    }
   };
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -222,83 +237,83 @@ export const ZooAdmin = () => {
       </div>
 
       {/* Lista de tarjetas */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center space-x-2">
-            <PawPrint className="w-5 h-5 text-blue-600" />
-            <span>Lista de Tarjetas de Animales</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {animals.map((animal) => (
-              <div
-                key={animal.id}
-                className="flex items-center space-x-4 p-4 border rounded-lg bg-white border-gray-200"
-              >
-                <img
-                  src={animal.image}
-                  alt={animal.name}
-                  className="w-16 h-16 object-cover rounded"
-                />
-                <div className="flex-1">
-                  <h4 className="font-medium text-gray-900">{animal.name}</h4>
-                  <p className="text-sm text-gray-600 italic">
-                    {animal.scientificName}
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1 line-clamp-2">
-                    {animal.description}
-                  </p>
-                </div>
-                <div className="flex space-x-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => handleEdit(animal)}
-                  >
-                    <Edit className="w-4 h-4" />
-                    Editar
-                  </Button>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {animals.map((animal) => (
+          <div
+            key={animal.id}
+            className={`bg-white rounded-lg shadow-lg overflow-hidden ${!animal.active ? "opacity-50" : ""}`}
+          >
+            <img
+              src={animal.image}
+              alt={animal.name}
+              className="w-full h-48 object-cover"
+            />
+            <div className="p-4">
+              <h3 className="font-bold text-park-blue mb-2">{animal.name}</h3>
+              <p className="text-sm text-park-orange italic mb-2">
+                {animal.scientificName}
+              </p>
+              <p className="text-sm text-gray-600 mb-4 line-clamp-2">
+                {animal.description}
+              </p>
 
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button size="sm" variant="destructive">
-                        <Trash2 className="w-4 h-4" />
+              {/* Botones de acción */}
+              <div className="flex space-x-2">
+                <button
+                  onClick={() => handleEdit(animal)}
+                  className="flex-1 bg-blue-500 hover:bg-blue-600 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1"
+                >
+                  <Edit className="w-4 h-4" />
+                  <span>Editar</span>
+                </button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <button className="flex-1 bg-red-500 hover:bg-red-600 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1">
+                      <Trash2 className="w-4 h-4" />
+                      <span>Eliminar</span>
+                    </button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>¿Eliminar tarjeta?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Esta acción no se puede deshacer. La tarjeta se
+                        eliminará permanentemente.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => handleDelete(animal.id)}
+                        className="bg-red-600 hover:bg-red-700"
+                      >
                         Eliminar
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>¿Eliminar tarjeta?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Esta acción no se puede deshacer. La tarjeta se
-                          eliminará permanentemente.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={() => handleDelete(animal.id)}
-                          className="bg-red-600 hover:bg-red-700"
-                        >
-                          Eliminar
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                </div>
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+                <button
+                  onClick={() => handleToggleActive(animal.id)}
+                  className={`flex-1 text-white text-sm py-2 px-3 rounded flex items-center justify-center space-x-1 ${animal.active ? "bg-gray-500 hover:bg-gray-600" : "bg-green-500 hover:bg-green-600"}`}
+                >
+                  {animal.active ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                  <span>{animal.active ? "Ocultar" : "Mostrar"}</span>
+                </button>
               </div>
-            ))}
-
-            {animals.length === 0 && (
-              <div className="text-center py-8 text-gray-500">
-                No hay animales. Haz clic en "Agregar" para añadir el primer
-                animal.
-              </div>
-            )}
+            </div>
           </div>
-        </CardContent>
-      </Card>
+        ))}
+      </div>
+
+      {animals.length === 0 && (
+        <div className="text-center py-8 text-gray-500">
+          No hay animales. Haz clic en "Agregar" para añadir el primer animal.
+        </div>
+      )}
 
       {/* Modal de edición */}
       <Dialog

--- a/src/lib/adminStorage.ts
+++ b/src/lib/adminStorage.ts
@@ -39,7 +39,6 @@ export interface PriceOption {
 export interface GroupImage {
   id: number;
   image: string;
-  alt: string;
   caption: string;
   active: boolean;
 }
@@ -268,28 +267,24 @@ const INITIAL_DATA: AdminData = {
     {
       id: 1,
       image: "/placeholder.svg",
-      alt: "Grupo disfrutando en el parque",
       caption: "Diversión familiar garantizada",
       active: true,
     },
     {
       id: 2,
       image: "/placeholder.svg",
-      alt: "Actividades en el zoológico",
       caption: "Experiencias educativas únicas",
       active: true,
     },
     {
       id: 3,
       image: "/placeholder.svg",
-      alt: "Zonas deportivas del parque",
       caption: "Espacios deportivos amplios",
       active: true,
     },
     {
       id: 4,
       image: "/placeholder.svg",
-      alt: "Área de picnic grupal",
       caption: "Perfectos para celebraciones",
       active: true,
     },


### PR DESCRIPTION
Remove alt text property from GroupImage interface and related components.

Changes made:
- Removed `alt` field from GroupImage interface in adminStorage.ts
- Updated GroupPricing component to use empty alt attribute for images
- Removed alt text input field from GroupsAdmin form
- Updated form validation to not require alt text
- Removed alt property from initial data in adminStorage.ts
- Added pointer-events-none class to MapSection overlay
- Replaced DialogTrigger with direct onClick handler in MapSection
- Updated admin layouts to use grid cards instead of list view
- Added toggle visibility functionality to ZooAdmin
- Removed unused EyeOff import from GroupsAdmin

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9da71d6611b14aa5a8d511bf9871a95c/mystic-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9da71d6611b14aa5a8d511bf9871a95c</projectId>-->
<!--<branchName>mystic-haven</branchName>-->